### PR TITLE
Add WTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Permanent URL to this list: https://github.com/iDoka/awesome-embedded-software
 * [HWlib](https://github.com/wovo/hwlib) - C++ OO micro-controller library for close-to-the-hardware programming.
 * [ctl](https://github.com/rurban/ctl) - C Container Template Library. There is a fast compiling, type safe, header only, template-like container library for ISO C99/C11.
 * [FSMLang](https://github.com/FSMLang/FSMLang) - State machine description language with C language generator. Supports flat and hierarchical machines and event subsystem.
-* [WTX](https://github.com/c410-f3r/wtx) - A set of web-oriented tools
 
 
 ## Memory
@@ -545,6 +544,7 @@ Computer Vision
 * [modm](https://github.com/modm-io/modm) - Barebone embedded C++20 library generator for AVR, SAM and ARM Cortex-M Microcontrollers (supported 3534 devices).
 * [cembed](https://github.com/rxi/cembed) - Small utility for embedding files in a C header.
 * [incbin](https://github.com/graphitemaster/incbin) - One-header library for compile-time embedding binary and textual files.
+* [WTX](https://github.com/c410-f3r/wtx) - A set of web-oriented tools
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Permanent URL to this list: https://github.com/iDoka/awesome-embedded-software
 * [HWlib](https://github.com/wovo/hwlib) - C++ OO micro-controller library for close-to-the-hardware programming.
 * [ctl](https://github.com/rurban/ctl) - C Container Template Library. There is a fast compiling, type safe, header only, template-like container library for ISO C99/C11.
 * [FSMLang](https://github.com/FSMLang/FSMLang) - State machine description language with C language generator. Supports flat and hierarchical machines and event subsystem.
+* [WTX](https://github.com/c410-f3r/wtx) - A set of tools for web development
 
 
 ## Memory

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Permanent URL to this list: https://github.com/iDoka/awesome-embedded-software
 * [HWlib](https://github.com/wovo/hwlib) - C++ OO micro-controller library for close-to-the-hardware programming.
 * [ctl](https://github.com/rurban/ctl) - C Container Template Library. There is a fast compiling, type safe, header only, template-like container library for ISO C99/C11.
 * [FSMLang](https://github.com/FSMLang/FSMLang) - State machine description language with C language generator. Supports flat and hierarchical machines and event subsystem.
-* [WTX](https://github.com/c410-f3r/wtx) - A set of tools for web development
+* [WTX](https://github.com/c410-f3r/wtx) - A set of web-oriented tools
 
 
 ## Memory

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Computer Vision
 * [modm](https://github.com/modm-io/modm) - Barebone embedded C++20 library generator for AVR, SAM and ARM Cortex-M Microcontrollers (supported 3534 devices).
 * [cembed](https://github.com/rxi/cembed) - Small utility for embedding files in a C header.
 * [incbin](https://github.com/graphitemaster/incbin) - One-header library for compile-time embedding binary and textual files.
-* [WTX](https://github.com/c410-f3r/wtx) - A set of web-oriented tools
+* [WTX](https://github.com/c410-f3r/wtx) - A set of web-oriented tools.
 
 ---
 


### PR DESCRIPTION
`WTX` is a library written in Rust intended to allow the development of web-oriented tools.

Every feature provided by the project, including an HTTP server, can be compiled to embedded devices. For example in https://c410-f3r.github.io/thoughts/securely-sending-dht22-sensor-data-from-an-esp32-board-to-postgresql a remote PostgreSQL connection was asynchronously established via WiFI using SCRAM-SHA-256 without channel binding over a TLS 1.3 session encrypted with the Aes128GcmSha256 cipher schema.