### PR TITLE
Add ForestHub.ai under AI ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Artificial Intelligence and Machine Learning
 * [caffepresso](https://github.com/gplhegde/caffepresso) - Optimized Library for Deep Learning on Embedded Accelerator-based platforms.
 * [libonnx](https://github.com/xboot/libonnx) - Lightweight, portable pure C99 onnx inference engine for embedded devices with hardware acceleration support.
 * [TinyMaix](https://github.com/sipeed/TinyMaix) - A tiny inference Neural Network library specifically for microcontrollers (TinyML). Designed to follow the rule: Easy-to-Use > Portable > Speed > Space.
+* [ForestHub.ai](https://foresthub.ai) - Embedded & edge AI agent platform with codegen for ESP32/STM32.
 
 ### CV
 


### PR DESCRIPTION
## Summary

Adds one entry under **Data processing → AI ML** for [ForestHub.ai](https://foresthub.ai) — an embedded & edge AI agent platform with codegen for ESP32/STM32.

## Why this fits

Sits alongside μTensor, nnom and TinyMaix which target ML inference on microcontrollers — ForestHub adds the agent layer (visual builder, generated embedded code, MQTT/HTTP delegation) on top.

## Disclosure

I'm affiliated with ForestHub.ai. Happy to adjust wording. Thanks for the list.