### PR TITLE
Add aem-modbus-simulator (Python Modbus slave) next to nanoMODBUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Permanent URL to this list: https://github.com/iDoka/awesome-embedded-software
 * [xmodem](https://github.com/bsail/xmodem) - XMODEM Library for embedded, mobile, iot, and desktop systems.
 * [TinyFrame](https://github.com/MightyPork/TinyFrame) - Simple library for building and parsing data frames for serial interfaces (like UART / RS232).
 * [nanoMODBUS](https://github.com/debevv/nanoMODBUS) - A compact MODBUS RTU/TCP C library for embedded/microcontrollers.
+* [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) - Open-source Python Modbus RTU/TCP slave simulator emulating an industrial DC monitor (147 holding registers, 6 baudrates). Useful for testing embedded firmware Modbus master implementations without physical slave hardware on the bench.
 * [rcobs](https://github.com/Dirbaio/rcobs) - Reverse-COBS encoding (rCOBS) is a variant of [COBS encoding](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) designed to allow encoding with zero lookahead.
 
 


### PR DESCRIPTION
## Summary

Adds [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) to the **Protocols** section, immediately after nanoMODBUS (the existing Modbus C library for embedded).

### What it is

Open-source Python Modbus RTU/TCP slave simulator emulating an industrial DC voltage monitor (147 holding registers, 8 DC channels, six baudrates 4,800-115,200). MIT license, pymodbus 2.x/3.x compatible.

### Why it fits next to nanoMODBUS

Embedded firmware engineers writing Modbus *master* code (using nanoMODBUS or any other client library) need a realistic Modbus *slave* to test against. This simulator provides exactly that:

- Test Modbus master firmware in CI pipelines without physical slave hardware
- Validate edge cases (invalid addresses, baudrate switching, threshold writes) deterministically
- Training environments for embedded systems courses

### Disclosure

I work at LRI (manufacturer of the simulated hardware). The simulator itself is fully open-source under MIT license.