### PR TITLE
Add Sensors: stm32-async-1wire — non-blocking 1-Wire master for STM32

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Computer Vision
 
 ### Sensors
 
-* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031.
+* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031; strong-pull-up parasite powering; released v1.6.1.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Permanent URL to this list: https://github.com/iDoka/awesome-embedded-software
   * [USB](#usb)
   * [Flash](#flash)
   * [CAN bus](#can-bus)
+  * [Sensors](#sensors)
 * [Others](#others)
   * [Thread management](#thread-management)
   * [Bootloaders](#bootloaders)
@@ -496,7 +497,9 @@ Computer Vision
 * [Canbus-Message](https://github.com/ReFil/Canbus-Message) - CAN message assembly and disassembly library for teensy & stm32.
 * [CanBoot](https://github.com/Arksine/CanBoot) -  Can Bootloader for MCUs (Currently lpc176x, stm32 and rp2040 MCUs are supported).
 
+### Sensors
 
+* [non-blocking-ds18B20-driver-for-stm32f103c8t6](https://github.com/a5021/non-blocking-ds18B20-driver-for-stm32f103c8t6) - Bare-metal, register-level DS18B20 (1-Wire) temperature driver for STM32; TIM1+DMA hardware-timed, non-blocking, interrupt-free, RTOS-agnostic, minimal CPU overhead.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Computer Vision
 
 ### Sensors
 
-* [non-blocking-ds18B20-driver-for-stm32f103c8t6](https://github.com/a5021/non-blocking-ds18B20-driver-for-stm32f103c8t6) - Bare-metal, register-level DS18B20 (1-Wire) temperature driver for STM32; TIM1+DMA hardware-timed, non-blocking, interrupt-free, RTOS-agnostic, minimal CPU overhead.
+* [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) - Non-blocking, register-level 1-Wire master for STM32 (DS18B20 temperature driver on top). Hardware-timed (TIM1+DMA, DMAMUX on G0), interrupt-free, RTOS-agnostic; header-only backends for STM32F1/F0/G0; hardware-validated on Blue Pill (F103) and STM32G031.
 
 ## Others
 


### PR DESCRIPTION
Adding [stm32-async-1wire](https://github.com/a5021/stm32-async-1wire) to the Sensors section.

- Non-blocking, register-level **1-Wire master for STM32**, with a DS18B20 temperature driver on top.
- Hardware-timed (TIM1 + DMA, DMAMUX on G0), fully polled — **no NVIC interrupts, interrupt-free, RTOS-agnostic**.
- Header-only backends for **STM32F1 / STM32F0 / STM32G0**, selected at build time via `make OW_TARGET=...`.
- **Hardware-validated** on Blue Pill (STM32F103) and STM32G031F6P6; automatic parasite-power detection.
- MCU-independent core (`src/onewire.c` + `src/ds18b20.c`) over a small `ow_port_*` port interface.

Single-task safe by design; serialize with a mutex if calling from multiple RTOS tasks.

---
Recent updates since submission: STM32F0 and STM32G0 backends added (DMAMUX on G0), G0 hardware-validated on STM32G031F6P6, automatic parasite-power detection, strong-pull-up refinement for robust parasite powering, and tagged releases up to **v1.6.1**.